### PR TITLE
fix config.yml loading when called by external wrapper script

### DIFF
--- a/syslog2jabber.rb
+++ b/syslog2jabber.rb
@@ -9,7 +9,7 @@ require 'file/tail'
 require 'socket'
 require 'time'
 
-config = YAML.load_file('config.yml')
+config = YAML::load_file(File.join(File.dirname(File.expand_path(__FILE__)), 'config.yml'))
 
 
 Jabber::debug = config[:jabber_debug] ||= false


### PR DESCRIPTION
Hello,

I've created a wrapper to syslog2jabber.rb called **application.rb**:

``` ruby
require 'daemons'

Daemons.run('syslog2jabber.rb')
```

So, when I call it as:

``` sh
ruby application.rb run
```

I get the following error:

/usr/lib64/ruby/2.0.0/psych.rb:299:in `initialize': No such file or directory - config.yml (Errno::ENOENT)

I'm sending you a fix, so it works with or without the wrapper script.
